### PR TITLE
Update phpMockServer.php

### DIFF
--- a/src/phpMockServer.php
+++ b/src/phpMockServer.php
@@ -292,6 +292,7 @@ class phpMockServer
         if ($count == $timeout) {
             $this->response->setContent('Timeout');
             $this->response->setStatusCode(500);
+            return;
         }
         $this->response->setContent(file_get_contents($datapath));
         $this->response->setStatusCode(200);

--- a/src/phpMockServer.php
+++ b/src/phpMockServer.php
@@ -286,6 +286,7 @@ class phpMockServer
         $timeout = $this->request->headers->get("X-timeout", 60);
         $count = 0;
         while ($count < $timeout && !file_exists($datapath)) {
+            clearstatcache();
             sleep(1);
             $count++;
         }


### PR DESCRIPTION
- `readMockedRequest` should not read not exist file and not return 200 status when file not exist.
- Adjustment to clear cache when we want to check by file_exists cached result on a regular basis.