### PR TITLE
Attempt to create directory multiple times before throwing an exception

### DIFF
--- a/src/phpMockServer.php
+++ b/src/phpMockServer.php
@@ -266,9 +266,15 @@ class phpMockServer
         file_put_contents($datapath, json_encode($data));
     }
 
-    private function createDirectory($directoryName)
+    private function createDirectory($directoryName, int $attempt = 0)
     {
+        $attempt++;
         if (!is_dir($directoryName) && !@mkdir($directoryName, 0700, true) && !is_dir($directoryName)) {
+            if ($attempt < 10) {
+                usleep(200 * $attempt);
+                $this->createDirectory($directoryName, $attempt);
+                return;
+            }
             throw new \RuntimeException(sprintf('Directory "%s" could not be created', $directoryName));
         }
     }


### PR DESCRIPTION
The last fix was unfortunately not enough, we still saw some issues when the endpoint was called multiple times in parallel.

I created a small reproducer to verify the issue and also check if the fix works as expected:

**`race.php`**
```php
<?php

$url = 'http://localhost:8083/a/b/c/d/e/f/hellophp';
$response = file_get_contents($url);

if ($response !== 'Hallo PHP to /a/b/c/d/e/f/hellophp') {
    echo $response;
    echo PHP_EOL;
}
```

**`parallel`**
```bash
#!/bin/bash

php ./race.php &
php ./race.php &
php ./race.php &
php ./race.php &
php ./race.php &
php ./race.php &
php ./race.php &
php ./race.php &
php ./race.php &
php ./race.php &
php ./race.php &
wait
echo -n .

docker exec -it priceless_banzai rm -rf vendor/aldidigitalservices/php-mock-collector/data/GET/
                ^^^^^^^^^^^^^^^^
    (replace with your docker container id)
```

- `php race.php` will call the endpoint, that creates multiple subdirectories in `data/`
- `bash parallel` will call the previous script 11 times in parallel and remove the created folder inside the docker container afterward
- I tested that in a loop like so: `for i in $(seq 0 1 100); do bash parallel; done`
- Before: It worked most of the time, but sometimes failed with the error `<b>Fatal error</b>:  Uncaught RuntimeException: Directory &quot;/var/www/html/vendor/aldidigitalservices/php-mock-collector/src/../data/GET/a/b/c/d/e/f&quot; could not be created [...]`
- After: Does not fail anymore