### PR TITLE
Do not require body for OPTIONS

### DIFF
--- a/src/phpMockServer.php
+++ b/src/phpMockServer.php
@@ -104,7 +104,7 @@ class phpMockServer
                     throw new \Exception('No callback found.');
                 }
             } catch (\Exception $e) {
-                $this->response->setContent("Failed to call customCallbock:" . $conf[self::MOCK_KEY_CUSTOM_CALLBACK] . PHP_EOL . $e->getMessage());
+                $this->response->setContent("Failed to call customCallback:" . $conf[self::MOCK_KEY_CUSTOM_CALLBACK] . PHP_EOL . $e->getMessage());
                 return false;
             }
 
@@ -169,7 +169,7 @@ class phpMockServer
     protected function selectMatchingConfig()
     {
         $config = $this->getMockConfig();
-        $methode = $this->getMethode();
+        $method = $this->getMethod();
         if(isset($config['path'])){
 
             foreach ($config = $config['path'] as $path){
@@ -181,8 +181,8 @@ class phpMockServer
             }
         }
 
-        if (isset($config[$methode])) {
-            foreach ($config[$methode] as $key => $mock) {
+        if (isset($config[$method])) {
+            foreach ($config[$method] as $key => $mock) {
                 if (!isset($mock[self::MOCK_KEY_RULES]) or $this->checkRules($mock[self::MOCK_KEY_RULES])) {
                     return $mock;
                 }
@@ -216,7 +216,7 @@ class phpMockServer
         return "";
     }
 
-    private function getMethode()
+    private function getMethod()
     {
         if ($this->determineRequestType() != self::MOCKCALL) {
             $parts = explode("/", $this->request->getPathInfo());
@@ -289,7 +289,7 @@ class phpMockServer
             return;
         }
 
-        $datapath = __DIR__ . '/../data/' . $this->getMethode()
+        $datapath = __DIR__ . '/../data/' . $this->getMethod()
             . $this->getTrackingRequestId(DIRECTORY_SEPARATOR, '')
             . $this->getPath().".dat";
         $timeout = $this->request->headers->get("X-timeout", 60);

--- a/src/phpMockServer.php
+++ b/src/phpMockServer.php
@@ -129,7 +129,7 @@ class phpMockServer
         if (isset($conf[self::MOCK_KEY_HTTPCODE])) {
             $this->response->setStatusCode($conf[self::MOCK_KEY_HTTPCODE]);
         }
-        if (is_array($conf[self::MOCK_KEY_BODY])) {
+        if (is_array($conf[self::MOCK_KEY_BODY] ?? null)) {
             /* I would expect this to be moved to headers inside mock, and add additional key `bodyIsJson` by which encode the body. */
             $this->response->headers->set('Content-Type', 'application/json');
             $this->response->setContent(json_encode($conf[self::MOCK_KEY_BODY]));

--- a/src/phpMockServer.php
+++ b/src/phpMockServer.php
@@ -18,6 +18,8 @@ class phpMockServer
     const MOCK_KEY_HEADER = 'header';
     const MOCK_KEY_HTTPCODE = 'httpcode';
     const MOCK_KEY_BODY = 'body';
+    const MOCK_KEY_HTTP_METHOD = 'method';
+
     private $request;
     private $response;
     private const FETCHCALL = 1;
@@ -131,6 +133,8 @@ class phpMockServer
             /* I would expect this to be moved to headers inside mock, and add additional key `bodyIsJson` by which encode the body. */
             $this->response->headers->set('Content-Type', 'application/json');
             $this->response->setContent(json_encode($conf[self::MOCK_KEY_BODY]));
+        } elseif($conf[self::MOCK_KEY_HTTP_METHOD] == Request::METHOD_OPTIONS) {
+            $this->response->setContent($conf[self::MOCK_KEY_BODY] ?? null);
         } else {
             $this->response->setContent($conf[self::MOCK_KEY_BODY]);
         }
@@ -184,6 +188,7 @@ class phpMockServer
         if (isset($config[$method])) {
             foreach ($config[$method] as $key => $mock) {
                 if (!isset($mock[self::MOCK_KEY_RULES]) or $this->checkRules($mock[self::MOCK_KEY_RULES])) {
+                    $mock[self::MOCK_KEY_HTTP_METHOD] = $method;
                     return $mock;
                 }
             }

--- a/tests/PmcTest.php
+++ b/tests/PmcTest.php
@@ -99,14 +99,14 @@ final class PmcTest extends TestCase
         $this->assertEquals("/hello/world", $returnVal);
     }
 
-    public function testCanGetMethodeForFetchRequest(): void
+    public function testCangetMethodForFetchRequest(): void
     {
         $_SERVER['REQUEST_URI'] = "/getCallPayload/GET/hello";
         $_SERVER['REQUEST_METHOD'] = "GET";
         $m = new \ALDIDigitalServices\pms\phpMockServer(__DIR__."/__mocks");
         $returnVal = \ALDIDigitalServices\pms\PHPUnitUtil::callMethod(
             $m,
-            'getMethode'
+            'getMethod'
         );
         $this->assertEquals("GET", $returnVal);
 
@@ -114,19 +114,19 @@ final class PmcTest extends TestCase
         $m = new \ALDIDigitalServices\pms\phpMockServer(__DIR__."/__mocks");
         $returnVal = \ALDIDigitalServices\pms\PHPUnitUtil::callMethod(
             $m,
-            'getMethode'
+            'getMethod'
         );
         $this->assertEquals("POST", $returnVal);
     }
 
-    public function testCanGetMethodeForMockRequest(): void
+    public function testCangetMethodForMockRequest(): void
     {
         $_SERVER['REQUEST_URI'] = "/hello";
         $_SERVER['REQUEST_METHOD'] = "GET";
         $m = new \ALDIDigitalServices\pms\phpMockServer(__DIR__."/__mocks");
         $returnVal = \ALDIDigitalServices\pms\PHPUnitUtil::callMethod(
             $m,
-            'getMethode'
+            'getMethod'
         );
         $this->assertEquals("GET", $returnVal);
 
@@ -134,7 +134,7 @@ final class PmcTest extends TestCase
         $m = new \ALDIDigitalServices\pms\phpMockServer(__DIR__."/__mocks");
         $returnVal = \ALDIDigitalServices\pms\PHPUnitUtil::callMethod(
             $m,
-            'getMethode'
+            'getMethod'
         );
         $this->assertEquals("POST", $returnVal);
     }
@@ -268,7 +268,7 @@ final class PmcTest extends TestCase
             $m,
             'selectMatchingConfig'
         );
-        $this->assertEqualsCanonicalizing($returnVal,["header" => ['X-Bla' => "Hallo", "z-bla" => "z-bla"], "httpcode" => 200, "latency" => 5, "body" => "Hallo Welt"]);
+        $this->assertEqualsCanonicalizing($returnVal,["header" => ['X-Bla' => "Hallo", "z-bla" => "z-bla"], 'method' => 'GET', "httpcode" => 200, "latency" => 5, "body" => "Hallo Welt"]);
     }
 
     public function testGetConfigForWildcart(): void{
@@ -279,7 +279,7 @@ final class PmcTest extends TestCase
             $m,
             'selectMatchingConfig'
         );
-        $this->assertEqualsCanonicalizing($returnVal,["header" => ['X-Bla' => "Hallo", "z-bla" => "z-bla"], "httpcode" => 200,  "body" => "Hallo Wildcard"]);
+        $this->assertEqualsCanonicalizing($returnVal,["header" => ['X-Bla' => "Hallo", "z-bla" => "z-bla"], 'method' => 'GET', "httpcode" => 200,  "body" => "Hallo Wildcard"]);
     }
     public function testGetConfigForSecondWildcart(): void{
         $_SERVER['REQUEST_URI'] = "/wildcard/1/2/hallo";
@@ -289,7 +289,7 @@ final class PmcTest extends TestCase
             $m,
             'selectMatchingConfig'
         );
-        $this->assertEqualsCanonicalizing($returnVal,["header" => ['X-Bla' => "Hallo", "z-bla" => "z-bla"], "httpcode" => 200,  "body" => "Hallo Wildcard2"]);
+        $this->assertEqualsCanonicalizing($returnVal,["header" => ['X-Bla' => "Hallo", "z-bla" => "z-bla"], 'method' => 'GET', "httpcode" => 200,  "body" => "Hallo Wildcard2"]);
     }
     /*public function testProxy(): void
     {

--- a/tests/PmcTest.php
+++ b/tests/PmcTest.php
@@ -333,4 +333,17 @@ final class PmcTest extends TestCase
         $this->assertEquals("Preselection", $m->getResponseObject()->getContent());
     }
 
+    public function testOptionsRequestsDoNotRequireBody(): void
+    {
+        $_SERVER['REQUEST_URI'] = "/hello";
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+
+        $m = new \ALDIDigitalServices\pms\phpMockServer(__DIR__."/__mocks");
+        $returnVal = \ALDIDigitalServices\pms\PHPUnitUtil::callMethod(
+            $m,
+            'performMockRequest'
+        );
+        $this->assertEqualsCanonicalizing('',$m->getResponseObject()->getContent());
+    }
+
 }

--- a/tests/PmcTest.php
+++ b/tests/PmcTest.php
@@ -343,7 +343,12 @@ final class PmcTest extends TestCase
             $m,
             'performMockRequest'
         );
-        $this->assertEqualsCanonicalizing('',$m->getResponseObject()->getContent());
+
+        $headerArray = $m->getResponseObject()->headers->all();
+        $this->assertArrayHasKey('access-control-allow-headers', $headerArray);
+        $this->assertArrayHasKey('access-control-allow-origin', $headerArray);
+        $this->assertSame(['*'], $headerArray['access-control-allow-headers']);
+        $this->assertSame(['*'], $headerArray['access-control-allow-origin']);
     }
 
 }

--- a/tests/__mocks/hello/mock.json
+++ b/tests/__mocks/hello/mock.json
@@ -51,5 +51,14 @@
       "latency": 5,
       "body": "Hallo Welt"
     }
+  ],
+  "OPTIONS": [
+    {
+      "header": {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "*"
+      },
+      "httpcode": 200
+    }
   ]
 }


### PR DESCRIPTION
Several OPTIONS request has issues because of empty content body config.
We see basic php warnings presented in the response body complaining about non-present "body" keys in the config array. This also results with incomplete response data population (because the headers are already sent), so the access control headers are not set.

Although there could be a workaround by adding empty content in the config, the root cause is that the content is optional for these requests.